### PR TITLE
Updating some depedencies and moving to you own base python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3.6-alpine
+FROM docker-upgrade.artifactory.build.upgrade.com/python-base:2.0.20210421.0-222.3.7-232
 
+USER root
 ADD . /app
 WORKDIR /app
-RUN apk add --no-cache --virtual .build_deps gcc musl-dev \
-    && pip install -r requirements.txt \
-    && python setup.py install \
-    && apk del .build_deps gcc musl-dev
+RUN pip3 install -r requirements.txt \
+    && python3 setup.py install
+
+USER upgrade
 ENV TZ UTC
 
 CMD ["k8s-snapshots"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildDateVersionedDockerProject {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 google-api-python-client==1.6.2
-requests==2.20.0
 pykube==0.14.0
 tarsnapper==0.4.0
 aiochannel==0.2.2
@@ -11,6 +10,9 @@ isodate==0.5.4
 python-dateutil==2.6.0
 aiohttp==3.5.4
 aiostream==0.2.4
-boto3==1.9.220
+boto3==1.17.83
 yarl==1.1.1
 python-digitalocean==1.15.0
+urllib3==1.26.5
+setuptools==57.0.0
+requests==2.25.1


### PR DESCRIPTION
Trying an update to latest python_base + new boto3. Hoping this is a quick fix for our failing service with imdsv2 until we move to CSI ebs driver with snapshots support

+infra